### PR TITLE
Handle fields omitted through `@skip` or `@include`

### DIFF
--- a/examples/simple/expected/Operations/SkipNonNullable.php
+++ b/examples/simple/expected/Operations/SkipNonNullable.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spawnia\Sailor\Simple\Operations;
+
+/**
+ * @extends \Spawnia\Sailor\Operation<\Spawnia\Sailor\Simple\Operations\SkipNonNullable\SkipNonNullableResult>
+ */
+class SkipNonNullable extends \Spawnia\Sailor\Operation
+{
+    /**
+     * @param bool $value
+     */
+    public static function execute($value): SkipNonNullable\SkipNonNullableResult
+    {
+        return self::executeOperation(
+            $value,
+        );
+    }
+
+    protected static function converters(): array
+    {
+        static $converters;
+
+        return $converters ??= [
+            ['value', new \Spawnia\Sailor\Convert\NonNullConverter(new \Spawnia\Sailor\Convert\BooleanConverter)],
+        ];
+    }
+
+    public static function document(): string
+    {
+        return /* @lang GraphQL */ 'query SkipNonNullable($value: Boolean!) {
+          __typename
+          nonNullable @skip(if: $value)
+        }';
+    }
+
+    public static function endpoint(): string
+    {
+        return 'simple';
+    }
+
+    public static function config(): string
+    {
+        return \Safe\realpath(__DIR__ . '/../../sailor.php');
+    }
+}

--- a/examples/simple/expected/Operations/SkipNonNullable/SkipNonNullable.php
+++ b/examples/simple/expected/Operations/SkipNonNullable/SkipNonNullable.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spawnia\Sailor\Simple\Operations\SkipNonNullable;
+
+/**
+ * @property string $nonNullable
+ * @property string $__typename
+ */
+class SkipNonNullable extends \Spawnia\Sailor\ObjectLike
+{
+    /**
+     * @param string $nonNullable
+     */
+    public static function make($nonNullable): self
+    {
+        $instance = new self;
+
+        if ($nonNullable !== self::UNDEFINED) {
+            $instance->nonNullable = $nonNullable;
+        }
+        $instance->__typename = 'Query';
+
+        return $instance;
+    }
+
+    protected function converters(): array
+    {
+        static $converters;
+
+        return $converters ??= [
+            'nonNullable' => new \Spawnia\Sailor\Convert\NonNullConverter(new \Spawnia\Sailor\Convert\StringConverter),
+            '__typename' => new \Spawnia\Sailor\Convert\NonNullConverter(new \Spawnia\Sailor\Convert\StringConverter),
+        ];
+    }
+
+    public static function endpoint(): string
+    {
+        return 'simple';
+    }
+
+    public static function config(): string
+    {
+        return \Safe\realpath(__DIR__ . '/../../../sailor.php');
+    }
+}

--- a/examples/simple/expected/Operations/SkipNonNullable/SkipNonNullableErrorFreeResult.php
+++ b/examples/simple/expected/Operations/SkipNonNullable/SkipNonNullableErrorFreeResult.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spawnia\Sailor\Simple\Operations\SkipNonNullable;
+
+class SkipNonNullableErrorFreeResult extends \Spawnia\Sailor\ErrorFreeResult
+{
+    public SkipNonNullable $data;
+
+    public static function endpoint(): string
+    {
+        return 'simple';
+    }
+
+    public static function config(): string
+    {
+        return \Safe\realpath(__DIR__ . '/../../../sailor.php');
+    }
+}

--- a/examples/simple/expected/Operations/SkipNonNullable/SkipNonNullableResult.php
+++ b/examples/simple/expected/Operations/SkipNonNullable/SkipNonNullableResult.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spawnia\Sailor\Simple\Operations\SkipNonNullable;
+
+class SkipNonNullableResult extends \Spawnia\Sailor\Result
+{
+    public ?SkipNonNullable $data = null;
+
+    protected function setData(\stdClass $data): void
+    {
+        $this->data = SkipNonNullable::fromStdClass($data);
+    }
+
+    /**
+     * Useful for instantiation of successful mocked results.
+     *
+     * @return static
+     */
+    public static function fromData(SkipNonNullable $data): self
+    {
+        $instance = new static;
+        $instance->data = $data;
+
+        return $instance;
+    }
+
+    public function errorFree(): SkipNonNullableErrorFreeResult
+    {
+        return SkipNonNullableErrorFreeResult::fromResult($this);
+    }
+
+    public static function endpoint(): string
+    {
+        return 'simple';
+    }
+
+    public static function config(): string
+    {
+        return \Safe\realpath(__DIR__ . '/../../../sailor.php');
+    }
+}

--- a/examples/simple/schema.graphql
+++ b/examples/simple/schema.graphql
@@ -2,6 +2,7 @@ type Query {
     scalarWithArg(arg: String): ID
     twoArgs(first: String, second: Int): ID
     singleObject: SomeObject
+    nonNullable: String!
 }
 
 type SomeObject {

--- a/examples/simple/src/clientDirectives.graphql
+++ b/examples/simple/src/clientDirectives.graphql
@@ -16,3 +16,7 @@ query ClientDirectiveInlineFragmentQuery($value: Boolean!) {
         twoArgs
     }
 }
+
+query SkipNonNullable($value: Boolean!) {
+    nonNullable @skip(if: $value)
+}

--- a/src/ObjectLike.php
+++ b/src/ObjectLike.php
@@ -98,8 +98,12 @@ abstract class ObjectLike implements TypeConverter, BelongsToEndpoint
         $converters = $this->converters();
         foreach ($converters as $name => $converter) {
             if (! property_exists($value, $name)) {
-                $endpoint = static::endpoint();
-                throw new InvalidDataException("{$endpoint}: Missing field {$name}.");
+                if ($name === '__typename') {
+                    $endpoint = static::endpoint();
+                    throw new InvalidDataException("{$endpoint}: Missing field {$name}.");
+                }
+                $instance->properties[$name] = self::UNDEFINED;
+                continue;
             }
 
             try {

--- a/tests/Integration/SimpleTest.php
+++ b/tests/Integration/SimpleTest.php
@@ -13,6 +13,7 @@ use Spawnia\Sailor\Simple\Operations\MyObjectNestedQuery;
 use Spawnia\Sailor\Simple\Operations\MyObjectNestedQuery\MyObjectNestedQueryResult;
 use Spawnia\Sailor\Simple\Operations\MyScalarQuery;
 use Spawnia\Sailor\Simple\Operations\MyScalarQuery\MyScalarQueryResult;
+use Spawnia\Sailor\Simple\Operations\SkipNonNullable\SkipNonNullable;
 use Spawnia\Sailor\Tests\TestCase;
 
 final class SimpleTest extends TestCase
@@ -205,5 +206,14 @@ final class SimpleTest extends TestCase
         $object = $result->data->singleObject;
         self::assertNotNull($object);
         self::assertNull($object->nested);
+    }
+
+    public function testSkipNonNullable(): void
+    {
+        SkipNonNullable::fromStdClass((object) [
+            'data' => (object) [
+                '__typename' => 'Query',
+            ],
+        ]);
     }
 }

--- a/tests/Integration/SimpleTest.php
+++ b/tests/Integration/SimpleTest.php
@@ -14,6 +14,7 @@ use Spawnia\Sailor\Simple\Operations\MyObjectNestedQuery\MyObjectNestedQueryResu
 use Spawnia\Sailor\Simple\Operations\MyScalarQuery;
 use Spawnia\Sailor\Simple\Operations\MyScalarQuery\MyScalarQueryResult;
 use Spawnia\Sailor\Simple\Operations\SkipNonNullable\SkipNonNullable;
+use Spawnia\Sailor\Simple\Operations\SkipNonNullable\SkipNonNullableResult;
 use Spawnia\Sailor\Tests\TestCase;
 
 final class SimpleTest extends TestCase
@@ -210,10 +211,13 @@ final class SimpleTest extends TestCase
 
     public function testSkipNonNullable(): void
     {
-        SkipNonNullable::fromStdClass((object) [
+        $result = SkipNonNullableResult::fromStdClass((object) [
             'data' => (object) [
                 '__typename' => 'Query',
             ],
         ]);
+        $object = $result->data;
+        self::assertNotNull($object);
+        self::assertSame(SkipNonNullable::UNDEFINED, $object->nonNullable);
     }
 }


### PR DESCRIPTION
https://github.com/spawnia/sailor/issues/77

- [X] Added automated tests
- [ ] Documented for all relevant versions
- [ ] Updated the changelog

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->
Builds upon https://github.com/spawnia/sailor/pull/79

**Changes**
When an operation tells the server to omit a field through @skip or @include, the result
will not contain those fields at all. Thus, the generated result will have the missing fields set to `ObjectLike::UNDEFINED` to mark them as such.

**Breaking changes**
Code that used to rely on exceptions being thrown when some property wasn't present in the response will need rework, as not only the exception will only be thrown if the `__typename` property isn't present, but also the result object will have the missing properties with the `string` value for `ObjectLike::UNDEFINED`.
